### PR TITLE
fix(playerbot): Add action bar override for dragonriding and fix spat…

### DIFF
--- a/src/modules/Playerbot/Dragonriding/DragonridingDefines.h
+++ b/src/modules/Playerbot/Dragonriding/DragonridingDefines.h
@@ -39,6 +39,15 @@ constexpr uint32 SPELL_THRILL_OF_THE_SKIES = 900008;  // High-speed flying regen
 constexpr uint32 SPELL_GROUND_SKIMMING = 900009;      // Near-ground flying regen buff
 
 // ============================================================================
+// ACTION BAR OVERRIDE
+// Used to swap the action bar to dragonriding abilities when Soar activates
+// ============================================================================
+
+// Custom OverrideSpellData ID (matches hotfix entry in override_spell_data)
+// This must be added to the hotfixes.override_spell_data table
+constexpr uint32 OVERRIDE_SPELL_DATA_DRAGONRIDING = 900001;
+
+// ============================================================================
 // FLIGHT CAPABILITY IDS
 // From FlightCapability.db2 - these activate dragonriding physics
 // ============================================================================

--- a/src/modules/Playerbot/Dragonriding/PlayerbotDragonridingScript.cpp
+++ b/src/modules/Playerbot/Dragonriding/PlayerbotDragonridingScript.cpp
@@ -162,7 +162,23 @@ class spell_playerbot_soar : public SpellScript
                 caster->GetName(), maxVigor);
         }
 
-        TC_LOG_INFO("playerbot.dragonriding", "Player {} activated Soar with {} vigor (account {})",
+        // Activate action bar override to show dragonriding abilities
+        // This uses the OverrideSpellData system to swap the action bar
+        caster->SetOverrideSpellsId(OVERRIDE_SPELL_DATA_DRAGONRIDING);
+
+        // Add temporary spells so they can be cast
+        // Base abilities (always available during dragonriding)
+        caster->AddTemporarySpell(SPELL_SURGE_FORWARD);
+        caster->AddTemporarySpell(SPELL_SKYWARD_ASCENT);
+
+        // Talent-locked abilities (only add if talent learned)
+        if (sDragonridingMgr->HasWhirlingSurge(accountId))
+            caster->AddTemporarySpell(SPELL_WHIRLING_SURGE);
+
+        if (sDragonridingMgr->HasAerialHalt(accountId))
+            caster->AddTemporarySpell(SPELL_AERIAL_HALT);
+
+        TC_LOG_INFO("playerbot.dragonriding", "Player {} activated Soar with {} vigor (account {}), action bar swapped",
             caster->GetName(), maxVigor, accountId);
     }
 
@@ -197,7 +213,16 @@ class spell_playerbot_soar_aura : public AuraScript
         target->RemoveAura(SPELL_THRILL_OF_THE_SKIES);
         target->RemoveAura(SPELL_GROUND_SKIMMING);
 
-        TC_LOG_DEBUG("playerbot.dragonriding", "Soar ended for player {}, dragonriding disabled",
+        // Remove action bar override and restore normal action bar
+        target->SetOverrideSpellsId(0);
+
+        // Remove temporary dragonriding spells
+        target->RemoveTemporarySpell(SPELL_SURGE_FORWARD);
+        target->RemoveTemporarySpell(SPELL_SKYWARD_ASCENT);
+        target->RemoveTemporarySpell(SPELL_WHIRLING_SURGE);
+        target->RemoveTemporarySpell(SPELL_AERIAL_HALT);
+
+        TC_LOG_DEBUG("playerbot.dragonriding", "Soar ended for player {}, dragonriding disabled, action bar restored",
             target->GetName());
     }
 

--- a/src/modules/Playerbot/sql/hotfixes/dragonriding_override_spells.sql
+++ b/src/modules/Playerbot/sql/hotfixes/dragonriding_override_spells.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- Playerbot Dragonriding System - Hotfix Data
+--
+-- This SQL adds a custom OverrideSpellData entry to enable action bar swap
+-- when dragonriding (Soar) is activated. This is how retail WoW handles
+-- showing dragonriding abilities on the action bar.
+--
+-- Install into: hotfixes database
+-- ============================================================================
+
+-- ============================================================================
+-- OVERRIDE_SPELL_DATA - Action Bar Override for Dragonriding
+--
+-- ID: 900001 (custom range to avoid conflicts with retail data)
+-- Contains the dragonriding boost abilities that appear on action bar:
+--   - Surge Forward (900002)
+--   - Skyward Ascent (900003)
+--   - Whirling Surge (900004)
+--   - Aerial Halt (900005)
+-- ============================================================================
+
+-- Delete any existing entry with our custom ID (for clean reinstall)
+DELETE FROM `override_spell_data` WHERE `ID` = 900001;
+
+-- Insert the dragonriding action bar override
+-- Spells1-4 contain our dragonriding abilities
+-- Spells5-10 are empty (0)
+-- PlayerActionBarFileDataID = 0 (use default action bar visual)
+-- Flags = 0 (no special flags)
+INSERT INTO `override_spell_data` (
+    `ID`,
+    `Spells1`, `Spells2`, `Spells3`, `Spells4`, `Spells5`,
+    `Spells6`, `Spells7`, `Spells8`, `Spells9`, `Spells10`,
+    `PlayerActionBarFileDataID`,
+    `Flags`,
+    `VerifiedBuild`
+) VALUES (
+    900001,
+    900002,  -- Surge Forward
+    900003,  -- Skyward Ascent
+    900004,  -- Whirling Surge (requires talent)
+    900005,  -- Aerial Halt (requires talent)
+    0,       -- Empty slot
+    0,       -- Empty slot
+    0,       -- Empty slot
+    0,       -- Empty slot
+    0,       -- Empty slot
+    0,       -- Empty slot
+    0,       -- Default action bar visual
+    0,       -- No special flags
+    1        -- VerifiedBuild > 0 means this entry is loaded
+);
+
+-- ============================================================================
+-- NOTES:
+--
+-- The OverrideSpellData system works as follows:
+-- 1. When an aura with SPELL_AURA_OVERRIDE_SPELLS (293) is applied,
+--    the MiscValue points to the OverrideSpellData ID
+-- 2. TrinityCore calls SetOverrideSpellsId() and AddTemporarySpell()
+-- 3. The client shows the spells from this entry on the action bar
+-- 4. When the aura is removed, the action bar returns to normal
+--
+-- Since our Soar spell uses custom spell scripts instead of DB2 auras,
+-- we manually call SetOverrideSpellsId() and AddTemporarySpell() in
+-- PlayerbotDragonridingScript.cpp when Soar is cast/removed.
+-- ============================================================================


### PR DESCRIPTION
…ial grid crash

- Add SetOverrideSpellsId() and AddTemporarySpell() calls when Soar activates to swap action bar to dragonriding abilities (Surge Forward, Skyward Ascent, etc.)
- Clean up action bar override and temporary spells when Soar aura is removed
- Add OVERRIDE_SPELL_DATA_DRAGONRIDING constant (900001) for hotfix entry
- Create SQL hotfix for override_spell_data table with dragonriding ability slots
- Fix ACCESS_VIOLATION crash in DoubleBufferedSpatialGrid::PopulateBufferFromMap by adding try-catch exception handling around creature iteration
- Use snapshot approach to avoid iterator invalidation from concurrent modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [ ] master

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
